### PR TITLE
[feat] memoization on encodings

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -10,6 +10,8 @@ const Hoek = require('hoek');
 
 const internals = {};
 
+internals.cache = {};
+
 /*
     RFC 7231 Section 5.3.4 (https://tools.ietf.org/html/rfc7231#section-5.3.4)
 
@@ -25,14 +27,20 @@ const internals = {};
 
 exports.encoding = function (header, preferences) {
 
-    const encodings = exports.encodings(header, preferences);
-    return encodings.length ? encodings[0] : '';
+    Hoek.assert(!preferences || Array.isArray(preferences), 'Preferences must be an array');
+
+    const label = preferences ? header.concat(preferences.join('')) : header;
+    if (!internals.cache[label]) {
+        const encodings = exports.encodings(header, preferences);
+        const output = encodings.length ? encodings[0] : '';
+        internals.cache[label] = output;
+        return output;
+    }
+    return internals.cache[label];
 };
 
 
 exports.encodings = function (header, preferences) {
-
-    Hoek.assert(!preferences || Array.isArray(preferences), 'Preferences must be an array');
 
     const scores = internals.parse(header, 'encoding');
     if (!preferences) {

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -25,6 +25,27 @@ const expect = Code.expect;
     Accept-Encoding: gzip;q=1.0, identity; q=0.5, *;q=0
 */
 
+describe('encoding memoization', () => {
+
+    it('memoizes without preferences', () => {
+
+        const encoding1 = Accept.encoding('gzip;q=1.0, identity; q=0.5, *;q=0');
+        expect(encoding1).to.equal('gzip');
+
+        const encoding2 = Accept.encoding('gzip;q=1.0, identity; q=0.5, *;q=0');
+        expect(encoding2).to.equal('gzip');
+    });
+
+    it('memoizes with preferences', () => {
+
+        const encoding1 = Accept.encoding('gzip;q=1.0, identity; q=0.5, *;q=0', ['identity', 'deflate', 'gzip']);
+        expect(encoding1).to.equal('gzip');
+
+        const encoding2 = Accept.encoding('gzip;q=1.0, identity; q=0.5, *;q=0', ['identity', 'deflate', 'gzip']);
+        expect(encoding2).to.equal('gzip');
+    });
+});
+
 describe('encoding()', () => {
 
     it('parses header', () => {


### PR DESCRIPTION
# improvements

| Accept-Encodings    | Hapi 14 | Hapi 14 Memoized |
| ------------------- | ------- | -----------------|
| Requests Per second | 5922.30 | 6278.80          |

| Accept-Encodings    | Hapi 16 | Hapi 16 Memoized |
| ------------------- | ------- | -----------------|
| Requests Per second | 5056.80  | 5604.05         |

| Accept-Encodings    | Hapi 17 | Hapi 17 Memoized |
| ------------------- | ------- | -----------------|
| Requests Per second | 8205.22 | 8937.10        |

# Command
	ab -c 64 -n 100000 -H "Accept-Encoding: identity, gzip, deflate, br" "http://127.0.0.1:3000/"

Similar across the board delta improvements for gzip first (e.g. Chrome browser). [Serving](https://gist.githubusercontent.com/rook2pawn/c92b5abb131c05f34af921e6f5a0f5f1/raw/03aee16554f8603b66346500434f40ea343e2588/server.js) moderately sized text.

### remove TCP bottlenecks
	sysctl net.ipv4.tcp_tw_recycle=1
	sysctl net.ipv4.tcp_tw_reuse=1
	sysctl net.core.somaxconn=1024
#### confirm via ss utility (socket statistics)
	// results of the following line should be empty
	ss -tapo4 (t for TCP, a for all states,  p for show connected process, 4 for ipv4)
