### PR TITLE
[feat] hardcoded responses for most common Accept-Encoding

### DIFF
--- a/lib/encoding.js
+++ b/lib/encoding.js
@@ -11,6 +11,42 @@ const Hoek = require('hoek');
 const internals = {};
 
 /*
+    gzip, deflate = most browsers (safari, chrome on iphone6s & ipad air),
+       (chrome on android), (firefox, edge on win10), (chrome, safari on desktop)
+    gzip, deflate, br = chrome on https or localhost
+    gzip, deflate, sdch = firefox win7
+    identity, gzip = for benchmark
+*/
+internals.commonAcceptEncodings = [
+    'gzip, deflate',
+    'gzip, deflate, br',
+    'gzip, deflate, sdch',
+    'identity, gzip'
+];
+
+// from hapi/lib/compression.js
+internals.commonPreferences = [
+    ['identity', 'gzip', 'deflate'],
+    ['identity', 'deflate', 'gzip'],
+    undefined
+];
+
+internals.cache = {};
+
+internals.generateCache = function (encodingHeaders, preferencesList) {
+
+    encodingHeaders.forEach((header) => {
+
+        preferencesList.forEach((preferences) => {
+
+            const result = exports.encoding(header, preferences);
+            const label = preferences ? header.concat(preferences.join('')) : header;
+            internals.cache[label] = result;
+        });
+    });
+};
+
+/*
     RFC 7231 Section 5.3.4 (https://tools.ietf.org/html/rfc7231#section-5.3.4)
 
     Accept-Encoding  = #( codings [ weight ] )
@@ -25,14 +61,19 @@ const internals = {};
 
 exports.encoding = function (header, preferences) {
 
-    const encodings = exports.encodings(header, preferences);
-    return encodings.length ? encodings[0] : '';
+    Hoek.assert(!preferences || Array.isArray(preferences), 'Preferences must be an array');
+
+    const label = preferences ? header.concat(preferences.join('')) : header;
+    if (!internals.cache[label]) {
+        const encodings = exports.encodings(header, preferences);
+        const output = encodings.length ? encodings[0] : '';
+        return output;
+    }
+    return internals.cache[label];
 };
 
 
 exports.encodings = function (header, preferences) {
-
-    Hoek.assert(!preferences || Array.isArray(preferences), 'Preferences must be an array');
 
     const scores = internals.parse(header, 'encoding');
     if (!preferences) {
@@ -139,3 +180,5 @@ internals.sort = function (a, b) {
 
     return (a.score === b.score ? 0 : (a.score < b.score ? 1 : -1));
 };
+
+internals.generateCache(internals.commonAcceptEncodings, internals.commonPreferences);

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -25,6 +25,33 @@ const expect = Code.expect;
     Accept-Encoding: gzip;q=1.0, identity; q=0.5, *;q=0
 */
 
+describe('encoding hardcoded responses', () => {
+
+    it('cache hit without preferences', () => {
+
+        const encoding1 = Accept.encoding('gzip, deflate');
+        expect(encoding1).to.equal('gzip');
+    });
+
+    it('cache hit with preferences', () => {
+
+        const encoding1 = Accept.encoding('gzip, deflate', ['identity', 'deflate', 'gzip']);
+        expect(encoding1).to.equal('deflate');
+    });
+
+    it('cache miss without preferences', () => {
+
+        const encoding1 = Accept.encoding('br, compress');
+        expect(encoding1).to.equal('br');
+    });
+
+    it('cache miss with preferences', () => {
+
+        const encoding1 = Accept.encoding('br, compress', ['identity', 'deflate', 'gzip']);
+        expect(encoding1).to.equal('identity');
+    });
+});
+
 describe('encoding()', () => {
 
     it('parses header', () => {


### PR DESCRIPTION
see #23 
 
# improvements

| Accept-Encodings    | Hapi 14 | Hapi 14 Memoized |
| ------------------- | ------- | -----------------|
| Requests Per second | 5922.30 | 6278.80          |

| Accept-Encodings    | Hapi 16 | Hapi 16 Memoized |
| ------------------- | ------- | -----------------|
| Requests Per second | 5056.80  | 5604.05         |

| Accept-Encodings    | Hapi 17 | Hapi 17 Memoized |
| ------------------- | ------- | -----------------|
| Requests Per second | 8205.22 | 9154.04         |

# Command
	ab -c 64 -n 100000 -H "Accept-Encoding: identity, gzip" "http://127.0.0.1:3000/"

Similar across the board delta improvements for gzip first (e.g. Chrome browser). [Serving](https://gist.githubusercontent.com/rook2pawn/c92b5abb131c05f34af921e6f5a0f5f1/raw/03aee16554f8603b66346500434f40ea343e2588/server.js) moderately sized text.

### remove TCP bottlenecks
	sysctl net.ipv4.tcp_tw_recycle=1
	sysctl net.ipv4.tcp_tw_reuse=1
	sysctl net.core.somaxconn=1024
#### confirm via ss utility (socket statistics)
	// results of the following line should be empty
	ss -tapo4 (t for TCP, a for all states,  p for show connected process, 4 for ipv4)
