### PR TITLE
fix: parse accept-language prefixes

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -71,6 +71,35 @@ exports.selections = function (header, preferences, options) {
 //       qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
 
 
+internals.findPreferred = function (preferences, token) {
+
+    const matches = [];
+    const tokenParts = token.split('-');
+    const tokenLength = tokenParts.length;
+
+    outer: for (let i = 0; i < preferences.length; ++i) {
+        const preference = preferences[i];
+        const preferenceParts = preference.split('-');
+        const preferenceLength = preferenceParts.length;
+
+        if (tokenLength > preferenceLength) {
+            continue;
+        }
+
+        for (let j = 0; j < tokenLength; ++j) {
+            if (tokenParts[j].toLowerCase() !== preferenceParts[j].toLowerCase()) {
+                continue outer;
+            }
+        }
+
+        matches.push(preference.toLowerCase());
+    }
+
+    matches.sort((a, b) => a.split('-').length - b.split('-').length);
+
+    return matches;
+};
+
 internals.parse = function (raw, preferences, options) {
 
     // Normalize header (remove spaces and tabs)
@@ -94,19 +123,19 @@ internals.parse = function (raw, preferences, options) {
     const map = new Set();
 
     for (let i = 0; i < parts.length; ++i) {
-        const part = parts[i];
+        const part = parts[i];  // de-DE;q=0.9
         if (!part) {                            // Ignore empty parts or leading commas
             continue;
         }
 
         // Parse parameters
 
-        const params = part.split(';');
+        const params = part.split(';'); // ['de-DE', 'q=0.9']
         if (params.length > 2) {
             throw Boom.badRequest(`Invalid ${options.type} header`);
         }
 
-        let token = params[0].toLowerCase();
+        let token = params[0].toLowerCase();  // 'de-de'
         if (!token) {
             throw Boom.badRequest(`Invalid ${options.type} header`);
         }
@@ -118,19 +147,38 @@ internals.parse = function (raw, preferences, options) {
         }
 
         const selection = {
-            token,
+            token,  // de-de
             pos: i,
-            q: 1,
-            specificity: options.specificity ? token.split('-') : null
+            q: 1,  // just the default
+            specificity: options.specificity ? token.split('-') : null // ['de', 'de']
         };
 
-        if (preferences &&
-            lowers.has(token)) {
+        if (preferences) {
+            if (options.type === 'accept-language') {
+                const matches = internals.findPreferred(
+                    preferences,
+                    selection.token
+                );
+                if (matches.length) {
+                    selection.pref = lowers.get(matches[0]).pos;
+                }
 
-            selection.pref = lowers.get(token).pos;
+            }
+            else if (lowers.has(token)) {
+                selection.pref = lowers.get(token).pos;
+            }
         }
 
-        map.add(selection.token);
+        if (options.type === 'accept-language' && preferences) {
+            const matches = internals.findPreferred(
+                preferences,
+                selection.token
+            );
+            map.add(matches.length ? matches[0] : selection.token);
+        }
+        else {
+            map.add(selection.token);
+        }
 
         // Parse q=value
 
@@ -191,8 +239,19 @@ internals.parse = function (raw, preferences, options) {
         }
         else {
             const lower = selection.toLowerCase();
-            if (lowers.has(lower)) {
-                preferred.push(lowers.get(lower).orig);
+            if (options.type === 'accept-language') {
+                const matches = internals.findPreferred(
+                    preferences,
+                    lower
+                );
+                if (matches.length) {
+                    preferred.push(lowers.get(matches[0]).orig);
+                }
+            }
+            else {
+                if (lowers.has(lower)) {
+                    preferred.push(lowers.get(lower).orig);
+                }
             }
         }
     }
@@ -210,6 +269,13 @@ internals.sort = function (a, b) {
         return b.q - a.q;
     }
 
+    if (a.specificity &&
+        a.specificity[0] === b.specificity[0] &&
+        a.specificity.length !== b.specificity.length) {
+
+        return b.specificity.length - a.specificity.length;
+    }
+
     if (b.pref !== a.pref) {
         if (a.pref === undefined) {
             return bFirst;
@@ -220,13 +286,6 @@ internals.sort = function (a, b) {
         }
 
         return a.pref - b.pref;
-    }
-
-    if (a.specificity &&
-        a.specificity[0] === b.specificity[0] &&
-        a.specificity.length !== b.specificity.length) {
-
-        return b.specificity.length - a.specificity.length;
     }
 
     return a.pos - b.pos;

--- a/lib/header.js
+++ b/lib/header.js
@@ -104,19 +104,19 @@ internals.parse = function (raw, preferences, options) {
     const map = new Set();
 
     for (let i = 0; i < parts.length; ++i) {
-        const part = parts[i];  // de-DE;q=0.9
+        const part = parts[i];
         if (!part) {                            // Ignore empty parts or leading commas
             continue;
         }
 
         // Parse parameters
 
-        const params = part.split(';'); // ['de-DE', 'q=0.9']
+        const params = part.split(';');
         if (params.length > 2) {
             throw Boom.badRequest(`Invalid ${options.type} header`);
         }
 
-        let token = params[0].toLowerCase();  // 'de-de'
+        let token = params[0].toLowerCase();
         if (!token) {
             throw Boom.badRequest(`Invalid ${options.type} header`);
         }
@@ -128,10 +128,10 @@ internals.parse = function (raw, preferences, options) {
         }
 
         const selection = {
-            token,  // de-de
+            token,
             pos: i,
-            q: 1,  // just the default
-            specificity: options.specificity ? token.split('-') : null // ['de', 'de']
+            q: 1,
+            specificity: options.specificity ? token.split('-') : null
         };
 
         if (preferences && lowers.has(token)) {

--- a/lib/header.js
+++ b/lib/header.js
@@ -70,36 +70,6 @@ exports.selections = function (header, preferences, options) {
 //       weight = OWS ";" OWS "q=" qvalue
 //       qvalue = ( "0" [ "." 0*3DIGIT ] ) / ( "1" [ "." 0*3("0") ] )
 
-
-internals.findPreferred = function (preferences, token) {
-
-    const matches = [];
-    const tokenParts = token.split('-');
-    const tokenLength = tokenParts.length;
-
-    outer: for (let i = 0; i < preferences.length; ++i) {
-        const preference = preferences[i];
-        const preferenceParts = preference.split('-');
-        const preferenceLength = preferenceParts.length;
-
-        if (tokenLength > preferenceLength) {
-            continue;
-        }
-
-        for (let j = 0; j < tokenLength; ++j) {
-            if (tokenParts[j].toLowerCase() !== preferenceParts[j].toLowerCase()) {
-                continue outer;
-            }
-        }
-
-        matches.push(preference.toLowerCase());
-    }
-
-    matches.sort((a, b) => a.split('-').length - b.split('-').length);
-
-    return matches;
-};
-
 internals.parse = function (raw, preferences, options) {
 
     // Normalize header (remove spaces and tabs)
@@ -112,7 +82,18 @@ internals.parse = function (raw, preferences, options) {
     if (preferences) {
         for (let i = 0; i < preferences.length; ++i) {
             const preference = preferences[i];
-            lowers.set(preference.toLowerCase(), { orig: preference, pos: i });
+            const lowerPreference = preference.toLowerCase();
+            lowers.set(lowerPreference, { orig: preference, pos: i });
+            if ( options.type === 'accept-language') {
+                const languageParts = lowerPreference.split('-');
+                languageParts.pop();
+
+                while (languageParts.length) {
+                    lowers.set(languageParts.join('-'), { orig: preference, pos: i });
+                    languageParts.pop();
+                }
+
+            }
         }
     }
 
@@ -153,28 +134,12 @@ internals.parse = function (raw, preferences, options) {
             specificity: options.specificity ? token.split('-') : null // ['de', 'de']
         };
 
-        if (preferences) {
-            if (options.type === 'accept-language') {
-                const matches = internals.findPreferred(
-                    preferences,
-                    selection.token
-                );
-                if (matches.length) {
-                    selection.pref = lowers.get(matches[0]).pos;
-                }
-
-            }
-            else if (lowers.has(token)) {
-                selection.pref = lowers.get(token).pos;
-            }
+        if (preferences && lowers.has(token)) {
+            selection.pref = lowers.get(token).pos;
         }
 
-        if (options.type === 'accept-language' && preferences) {
-            const matches = internals.findPreferred(
-                preferences,
-                selection.token
-            );
-            map.add(matches.length ? matches[0] : selection.token);
+        if (preferences && lowers.has(selection.token)) {
+            map.add(lowers.get(selection.token).orig);
         }
         else {
             map.add(selection.token);
@@ -239,19 +204,8 @@ internals.parse = function (raw, preferences, options) {
         }
         else {
             const lower = selection.toLowerCase();
-            if (options.type === 'accept-language') {
-                const matches = internals.findPreferred(
-                    preferences,
-                    lower
-                );
-                if (matches.length) {
-                    preferred.push(lowers.get(matches[0]).orig);
-                }
-            }
-            else {
-                if (lowers.has(lower)) {
-                    preferred.push(lowers.get(lower).orig);
-                }
+            if (lowers.has(lower)) {
+                preferred.push(lowers.get(lower).orig);
             }
         }
     }

--- a/test/language.js
+++ b/test/language.js
@@ -72,7 +72,7 @@ describe('language()', () => {
 
     it('returns preference with highest specificity', () => {
 
-        expect(Accept.language('da, en, en-GB', ['en', 'en-GB'])).to.equal('en');
+        expect(Accept.language('da, en, en-GB', ['en', 'en-GB'])).to.equal('en-GB');
         expect(Accept.language('da, en, en-GB', ['en-GB', 'en'])).to.equal('en-GB');
         expect(Accept.language('en, en-GB, en-US')).to.equal('en-gb');
     });

--- a/test/language.js
+++ b/test/language.js
@@ -77,7 +77,7 @@ describe('language()', () => {
         expect(Accept.language('en, en-GB, en-US')).to.equal('en-gb');
     });
 
-    it('return language with heighest weight', () => {
+    it('returns language with heighest weight', () => {
 
         const language = Accept.language('da;q=0.5, en;q=1', ['da', 'en']);
         expect(language).to.equal('en');
@@ -87,6 +87,12 @@ describe('language()', () => {
 
         const language = Accept.language('da, en-GB, en', ['en-us', 'en-gb']); // en-GB vs en-gb
         expect(language).to.equal('en-gb');
+    });
+
+    it('returns a more specific preference if a less specific one is requested', () => {
+
+        const language = Accept.language('de-LI,de', ['en-us', 'de-de']);
+        expect(language).to.equal('de-de');
     });
 });
 
@@ -123,15 +129,16 @@ describe('languages()', () => {
         expect(languages).to.equal(['da', 'en-gb', 'es', 'en']);
     });
 
-    it('return empty array when no header is present', () => {
+    it('returns empty array when no header is present', () => {
 
         const languages = Accept.languages();
         expect(languages).to.equal([]);
     });
 
-    it('return empty array when header is empty', () => {
+    it('returns empty array when header is empty', () => {
 
         const languages = Accept.languages('');
         expect(languages).to.equal([]);
     });
+
 });


### PR DESCRIPTION
This is a work-in-progress for fixing #63.

We also have some questions concerning the order of precedence when parsing the accept language.
[This test](https://github.com/strangedev/accept/blob/b37af808ffe3cca83037df76c1bca13575144fc2/test/language.js#L73) seems to imply in its description that when both `en-GB` and `en` are both offered by the server and accepted by the client, `en-GB` should always be chosen, as it is more specific than `en`. Are we missing something here?

@dotkuro and I plan on refactoring and testing this tomorrow.