### PR TITLE
Enable prefix matching for language tags

### DIFF
--- a/API.md
+++ b/API.md
@@ -43,7 +43,9 @@ const encodings = Accept.encodings("compress;q=0.5, gzip;q=1.0"); // encodings =
 
 ### `language(languageHeader, [preferences])`
 
-Given a string of acceptable languages from a HTTP request Accept-Language header, and an optional array of language preferences, it will return a string indicating the best language that can be used in the HTTP response.  It respects the [q weightings](#weightings) of the languages in the header, returning the matched preference with the highest weighting.  The case of the preference does not have to match the case of the option in the header.  
+Given a string of acceptable language ranges from a HTTP request Accept-Language header, and an optional array of language-tag preferences, it will return a string indicating the best language that can be used in the HTTP response.  It respects the [q weightings](#weightings) of the languages in the header, returning the matched preference with the highest weighting.  The case of the preference does not have to match the case of the option in the header.
+
+If preferences is missing or an empty array, the highest weighted language is returned.  If no preference matches, an empty string is returned.
 
 ```
 const language = Accept.language("en;q=0.7, en-GB;q=0.8"); // language === "en-gb"

--- a/lib/header.js
+++ b/lib/header.js
@@ -81,9 +81,20 @@ internals.parse = function (raw, preferences, options) {
 
     const lowers = new Map();
     if (preferences) {
-        for (let i = 0; i < preferences.length; ++i) {
-            const preference = preferences[i];
-            lowers.set(preference.toLowerCase(), { orig: preference, pos: i });
+        let pos = 0;
+        for (const preference of preferences) {
+            const lower = preference.toLowerCase();
+            lowers.set(lower, { orig: preference, pos: pos++ });
+
+            if (options.prefixMatch) {
+                const parts = lower.split('-');
+                while (parts.pop(), parts.length > 0) {
+                    const joined = parts.join('-');
+                    if (!lowers.has(joined)) {
+                        lowers.set(joined, { orig: preference, pos: pos++ });
+                    }
+                }
+            }
         }
     }
 
@@ -120,8 +131,7 @@ internals.parse = function (raw, preferences, options) {
         const selection = {
             token,
             pos: i,
-            q: 1,
-            specificity: options.specificity ? token.split('-') : null
+            q: 1
         };
 
         if (preferences &&
@@ -220,13 +230,6 @@ internals.sort = function (a, b) {
         }
 
         return a.pref - b.pref;
-    }
-
-    if (a.specificity &&
-        a.specificity[0] === b.specificity[0] &&
-        a.specificity.length !== b.specificity.length) {
-
-        return b.specificity.length - a.specificity.length;
     }
 
     return a.pos - b.pos;

--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ const internals = {
         },
         language: {
             type: 'accept-language',
-            specificity: true
+            prefixMatch: true
         }
     }
 };

--- a/test/language.js
+++ b/test/language.js
@@ -58,23 +58,23 @@ describe('language()', () => {
         expect(language).to.equal('');
     });
 
-    it('returns first preference if header has *', () => {
+    it('returns first preference if header has * and is unmatched', () => {
 
-        const language = Accept.language('da, en-GB, en, *', ['en-US']);
+        const language = Accept.language('da, en-GB, *', ['en-US']);
         expect(language).to.equal('en-US');
     });
 
     it('returns first found preference that header includes', () => {
 
         const language = Accept.language('da, en-GB, en', ['en-US', 'en-GB']);
-        expect(language).to.equal('en-GB');
+        expect(language).to.equal('en-US');
     });
 
-    it('returns preference with highest specificity', () => {
+    it('returns preference with highest order when equal weigths', () => {
 
         expect(Accept.language('da, en, en-GB', ['en', 'en-GB'])).to.equal('en');
         expect(Accept.language('da, en, en-GB', ['en-GB', 'en'])).to.equal('en-GB');
-        expect(Accept.language('en, en-GB, en-US')).to.equal('en-gb');
+        expect(Accept.language('en, en-GB, en-US')).to.equal('en');
     });
 
     it('return language with heighest weight', () => {
@@ -86,7 +86,23 @@ describe('language()', () => {
     it('ignores preference case when matching', () => {
 
         const language = Accept.language('da, en-GB, en', ['en-us', 'en-gb']); // en-GB vs en-gb
-        expect(language).to.equal('en-gb');
+        expect(language).to.equal('en-us');
+    });
+
+    it('returns language using range match', () => {
+
+        expect(Accept.language('da', ['da-DK'])).to.equal('da-DK');
+        expect(Accept.language('en-US, en', ['en-GB', 'en-US'])).to.equal('en-GB');
+        expect(Accept.language('da, en', ['da-DK', 'en-GB'])).to.equal('da-DK');
+        expect(Accept.language('en, da', ['da-DK', 'en-GB'])).to.equal('da-DK');
+        expect(Accept.language('en, da', ['en', 'en-GB'])).to.equal('en');
+        expect(Accept.language('da, en-GB', ['da-DK', 'en-GB'])).to.equal('da-DK');
+        expect(Accept.language('en, en-GB', ['en-US', 'en-GB', 'da-DK'])).to.equal('en-US');
+    });
+
+    it('explicit preference overrides range match', () => {
+
+        expect(Accept.language('da, en-GB', ['da-DK', 'en-GB', 'da'])).to.equal('en-GB');
     });
 });
 


### PR DESCRIPTION
This revises the implementation of `Accept.language()` to handle range matching.

Besides fixing the issue in #63, this patch also changes the behavior when matching against ranges with equal weights. This should have little consequence, as any client that cares about the priority will have set the weights.

This also fixes the implementation to not factor in specificity when selecting a language from equally weighted options without any preferences. I would classify this as a bug fix, since the behaviour was not documented, and does not make much sense.