### PR TITLE
Support node v18 and drop node v12

### DIFF
--- a/.github/workflows/ci-module.yml
+++ b/.github/workflows/ci-module.yml
@@ -10,3 +10,5 @@ on:
 jobs:
   test:
     uses: hapijs/.github/.github/workflows/ci-module.yml@master
+    with:
+      min-node-version: 14

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
-Copyright (c) 2014-2020, Sideway Inc, and project contributors  
-Copyright (c) 2015-2016, Mark Bradshaw  
-Copyright (c) 2014, Walmart.  
+Copyright (c) 2014-2022, Project contributors
+Copyright (c) 2014-2020, Sideway Inc
+Copyright (c) 2015-2016, Mark Bradshaw
+Copyright (c) 2014, Walmart.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/lib/header.js
+++ b/lib/header.js
@@ -122,9 +122,7 @@ internals.parse = function (raw, preferences, options) {
             throw Boom.badRequest(`Invalid ${options.type} header`);
         }
 
-        if (options.equivalents &&
-            options.equivalents.has(token)) {
-
+        if (options.equivalents?.has(token)) {
             token = options.equivalents.get(token);
         }
 
@@ -184,9 +182,7 @@ internals.parse = function (raw, preferences, options) {
         values.push(options.default);
     }
 
-    if (!preferences ||
-        !preferences.length) {
-
+    if (!preferences?.length) {
         return values;
     }
 

--- a/lib/media.js
+++ b/lib/media.js
@@ -238,9 +238,7 @@ internals.preferences = function (map, selections, preferences) {
 
     // Return selections if no preferences
 
-    if (!preferences ||
-        !preferences.length) {
-
+    if (!preferences?.length) {
         return selections.map((selection) => selection.token + selection.original);
     }
 
@@ -263,7 +261,7 @@ internals.preferences = function (map, selections, preferences) {
             continue;
         }
 
-        lowers[type] = lowers[type] || Object.create(null);
+        lowers[type] = lowers[type] ?? Object.create(null);
         lowers[type][subtype] = preference;
     }
 

--- a/package.json
+++ b/package.json
@@ -20,14 +20,15 @@
     ]
   },
   "dependencies": {
-    "@hapi/boom": "9.x.x",
-    "@hapi/hoek": "9.x.x"
+    "@hapi/boom": "^10.0.0",
+    "@hapi/hoek": "^10.0.0"
   },
   "devDependencies": {
-    "@hapi/code": "8.x.x",
+    "@hapi/code": "^9.0.0",
     "@hapi/eslint-plugin": "*",
-    "@hapi/lab": "24.x.x",
-    "typescript": "~4.0.2"
+    "@hapi/lab": "^25.0.1",
+    "@types/node": "^17.0.31",
+    "typescript": "~4.6.4"
   },
   "scripts": {
     "test": "lab -a @hapi/code -t 100 -L -Y",


### PR DESCRIPTION
 - Test on node v14+ and adopt some new syntax.
 - Update to node v18-compatible versions of hapi modules, update typescript.

If this looks good, this will go out as accept v6.